### PR TITLE
Update for Xcode13 and M1 Macs

### DIFF
--- a/Platform/Apple/ePub3.xcodeproj/project.pbxproj
+++ b/Platform/Apple/ePub3.xcodeproj/project.pbxproj
@@ -1944,7 +1944,7 @@
 		ABA72C1B1655382E003125FF /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 1240;
+				LastUpgradeCheck = 1320;
 				ORGANIZATIONNAME = "The Readium Foundation and contributors";
 			};
 			buildConfigurationList = ABA72C1E1655382E003125FF /* Build configuration list for PBXProject "ePub3" */;
@@ -2444,7 +2444,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -2492,7 +2492,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACOSX_DEPLOYMENT_TARGET = 10.8;
 				SDKROOT = macosx;
 			};

--- a/Platform/Apple/ePub3.xcodeproj/project.pbxproj
+++ b/Platform/Apple/ePub3.xcodeproj/project.pbxproj
@@ -2352,6 +2352,7 @@
 			buildSettings = {
 				CLANG_WARN_UNREACHABLE_CODE = NO;
 				DSTROOT = /tmp/ePub3_iOS.dst;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "../../ePub3-iOS/ePub3-iOS-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (

--- a/Platform/Apple/ePub3.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
+++ b/Platform/Apple/ePub3.xcodeproj/xcshareddata/xcschemes/UnitTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Platform/Apple/ePub3.xcodeproj/xcshareddata/xcschemes/ePub3-iOS.xcscheme
+++ b/Platform/Apple/ePub3.xcodeproj/xcshareddata/xcschemes/ePub3-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Platform/Apple/ePub3.xcodeproj/xcshareddata/xcschemes/ePub3.xcscheme
+++ b/Platform/Apple/ePub3.xcodeproj/xcshareddata/xcschemes/ePub3.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1240"
+   LastUpgradeVersion = "1320"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/ePub3/utilities/utfstring.h
+++ b/ePub3/utilities/utfstring.h
@@ -547,6 +547,8 @@ public:
         _base.swap(str._base);
     }
     
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-stack-address"
     EPUB3_EXPORT std::u32string utf32string() const;
     inline const_u4pointer utf32() const { return utf32string().c_str(); }
     
@@ -555,6 +557,7 @@ public:
 
 	EPUB3_EXPORT std::wstring wchar_string() const;
 	inline const wchar_t* wchar_str() const { return wchar_string().c_str(); }
+#pragma clang diagnostic pop
     
     __base::const_pointer c_str() const _NOEXCEPT { return _base.c_str(); }
     __base::const_pointer data() const _NOEXCEPT { return _base.data(); }


### PR DESCRIPTION
This PR changes some project settings to resolve issues on M1 Macs:

- performs Xcode recommended updates;
- silences warnings in unused code;
- excludes arm64 architecture from Simulators that failing on M1 simulators.