### PR TITLE
Make the library available on arm64 simulators

### DIFF
--- a/Platform/Apple/ePub3.xcodeproj/project.pbxproj
+++ b/Platform/Apple/ePub3.xcodeproj/project.pbxproj
@@ -2352,7 +2352,6 @@
 			buildSettings = {
 				CLANG_WARN_UNREACHABLE_CODE = NO;
 				DSTROOT = /tmp/ePub3_iOS.dst;
-				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "../../ePub3-iOS/ePub3-iOS-Prefix.pch";
 				GCC_PREPROCESSOR_DEFINITIONS = (


### PR DESCRIPTION
Removes arm64 from excluded architectures to support Xcode simulator support on M1 macs.